### PR TITLE
Race condition leads to stuck interrupt pin

### DIFF
--- a/include/KeyboardMatrix.h
+++ b/include/KeyboardMatrix.h
@@ -36,10 +36,12 @@ private:
   MCP23017 *_rows;
   MCP23017 *_columns;
 
-  static int GetBitPosition(uint16_t value);
-  void InitForRowDetection(bool setPullups);
   void CheckForButton();
   void CheckForRelease();
+  void InitForRowDetection(bool setPullups);
+  void DisableRowInterrupts();
+  void EnableRowInterrupts();
+  static int GetBitPosition(uint16_t value);
 
 public:
   KeyboardMatrix(uint8_t rowAddress, uint8_t columnAddress, uint8_t interruptPin, KeyboardEvent interruptHandler, ButtonEvent buttonHandler);


### PR DESCRIPTION
Fixes #7

* Split out MCP interrupt enable/disable code to separate methods
* Explicitly leave row interrupts disabled until button release is detected
* Set state machine state before re-enabling interrupts
