### PR TITLE
Build pilot and co-pilot firmware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Check out repo
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Cache PlatformIO
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out repo
       - uses: actions/checkout@v3
 
       - name: Cache PlatformIO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,19 +33,26 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade platformio
 
-      - name: Run PlatformIO
+      - name: Run PlatformIO - pilot
         env:
           VERSION: "0.0.${{ github.event.number }}"
+          BOARD_NUMBER: 1
+        run: pio run
+
+      - name: Run PlatformIO - co-pilot
+        env:
+          VERSION: "0.0.${{ github.event.number }}"
+          BOARD_NUMBER: 2
         run: pio run
 
       - name: Archive firmware
         uses: actions/upload-artifact@v2
         with:
           name: firmware
-          path: .pio/build/**/firmware*.hex
+          path: .pio/build/**/firmware*.uf2
 
       - name: Archive MobiFlight configuration files
         uses: actions/upload-artifact@v2
         with:
-          name: firmware
+          name: resources
           path: MobiFlight Resources/*.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -20,13 +20,13 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Cache PlatformIO
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.platformio
           key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       - name: Install PlatformIO
         run: |
@@ -46,13 +46,13 @@ jobs:
         run: pio run
 
       - name: Archive firmware
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: firmware
           path: .pio/build/**/firmware*.uf2
 
       - name: Archive MobiFlight configuration files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: resources
           path: MobiFlight Resources/*.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,10 @@ jobs:
       - name: Cache PlatformIO
         uses: actions/cache@v3
         with:
-          path: ~/.platformio
-          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -24,9 +26,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install PlatformIO
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade platformio
+        run: pip install --upgrade platformio
 
       - name: Run PlatformIO - pilot
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v4
+        with:
+          python-version: "3.9.10"
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
-          key: ${{ runner.os }}-pio }}
+          key: ${{ runner.os }}-pio
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Cache PlatformIO
         uses: actions/cache@v3
         with:
@@ -28,7 +20,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9.10"
+          python-version: "3.9"
+          cache: "pip"
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-          cache: "pip"
-          cache-dependency-path: "${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}"
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           python-version: "3.9"
           cache: "pip"
+          cache-dependency-path: "${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}"
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -14,6 +14,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          prefix: "Firmware for this pull request:"
-          format: "[Firmware.zip]({url})"
+          prefix: "Firmware and resources for this pull request:"
           addTo: pull

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Check out repo
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Cache PlatformIO
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,16 +36,23 @@ jobs:
         id: get_version
         uses: battila7/get-version-action@v2
 
-      - name: Run PlatformIO
+      - name: Run PlatformIO - pilot
         env:
           VERSION: ${{ steps.get_version.outputs.version-without-v }}
+          BOARD_NUMBER: 1
+        run: pio run
+
+      - name: Run PlatformIO - co-pilot
+        env:
+          VERSION: ${{ steps.get_version.outputs.version-without-v }}
+          BOARD_NUMBER: 2
         run: pio run
 
       - name: Archive firmware
         uses: actions/upload-artifact@v2
         with:
           name: firmware
-          path: .pio/build/**/firmware*.hex
+          path: .pio/build/**/firmware*.uf2
 
       - name: Archive MobiFlight configuration files
         uses: actions/upload-artifact@v2
@@ -59,5 +66,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            .pio/build/**/firmware*.hex
+            .pio/build/**/firmware*.uf2
             MobiFlight Resources/*.*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Cache PlatformIO
         uses: actions/cache@v3
         with:
@@ -28,7 +20,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9.10"
+          python-version: "3.9"
+          cache: "pip"
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out repo
       - uses: actions/checkout@v3
 
       - name: Cache PlatformIO

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v3
+        with:
+          python-version: "3.9.10"
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
-          key: ${{ runner.os }}-pio }}
+          key: ${{ runner.os }}-pio
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: "3.9"
-          cache: "pip"
-          cache-dependency-path: "${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}"
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           python-version: "3.9"
           cache: "pip"
+          cache-dependency-path: "${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}"
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -19,13 +20,13 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Cache PlatformIO
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.platformio
           key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
 
       - name: Install PlatformIO
         run: |
@@ -34,7 +35,7 @@ jobs:
 
       - name: Extract build version
         id: get_version
-        uses: battila7/get-version-action@v2
+        uses: battila7/get-version-action@v3
 
       - name: Run PlatformIO - pilot
         env:
@@ -49,13 +50,13 @@ jobs:
         run: pio run
 
       - name: Archive firmware
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: firmware
           path: .pio/build/**/firmware*.uf2
 
       - name: Archive MobiFlight configuration files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: firmware
           path: MobiFlight Resources/*.*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,10 @@ jobs:
       - name: Cache PlatformIO
         uses: actions/cache@v3
         with:
-          path: ~/.platformio
-          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio }}
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -24,9 +26,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install PlatformIO
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade platformio
+        run: pip install --upgrade platformio
 
       - name: Extract build version
         id: get_version

--- a/shared/get_version.py
+++ b/shared/get_version.py
@@ -1,22 +1,25 @@
 import os
 Import("env")
 
+# The names for the different FMS positions in the cockpit. Used
+# to generate output filename of the compiled firmware.
+board_position_name = ["pilot", "co-pilot"]
+
 # Get the version number from the build environment.
-firmware_version = os.environ.get('VERSION', "")
+firmware_version = os.environ.get('VERSION', "2.2.0")
+board_number = os.environ.get('BOARD_NUMBER', 1)
 
-# Clean up the version number
-if firmware_version == "":
-    # When no version is specified default to "0.0.1" for
-    # compatibility with MobiFlight desktop app version checks.
-    firmware_version = "2.2.0"
+# Convert board_number to origin 0 so it can be used to index into board_position_name.
+board_number -= 1
 
-print(f'Using version {firmware_version} for the build')
+print(f'Using version {firmware_version} position {board_position_name} ({board_number}) for the build')
 
 # Append the version to the build defines so it gets baked into the firmware
 env.Append(CPPDEFINES=[
-    f'BUILD_VERSION={firmware_version}'
+    f'BUILD_VERSION={firmware_version}',
+    f'MOBIFLIGHT_NAME=FMS 3000 - {board_number}'
 ])
 
 # Set the output filename to the name of the board and the version
 env.Replace(
-    PROGNAME=f'firmware_{env["PIOENV"]}_{firmware_version.replace(".", "_")}')
+    PROGNAME=f'firmware_{env["PIOENV"]}_{board_position_name[board_number]}_{firmware_version.replace(".", "_")}')

--- a/shared/get_version.py
+++ b/shared/get_version.py
@@ -7,12 +7,12 @@ board_position_name = ["pilot", "co-pilot"]
 
 # Get the version number from the build environment.
 firmware_version = os.environ.get('VERSION', "2.2.0")
-board_number = os.environ.get('BOARD_NUMBER', 1)
+raw_board_number = os.environ.get('BOARD_NUMBER', "1")
 
 # Convert board_number to origin 0 so it can be used to index into board_position_name.
-board_number -= 1
+board_number = int(raw_board_number) - 1
 
-print(f'Using version {firmware_version} position {board_position_name} ({board_number}) for the build')
+print(f'Using version {firmware_version} position {board_position_name[board_number]} ({raw_board_number}) for the build')
 
 # Append the version to the build defines so it gets baked into the firmware
 env.Append(CPPDEFINES=[

--- a/src/mobiflight.cpp
+++ b/src/mobiflight.cpp
@@ -12,7 +12,10 @@
 // The build version comes from an environment variable.
 #define STRINGIZER(arg) #arg
 #define STR_VALUE(arg) STRINGIZER(arg)
-#define VERSION STR_VALUE(BUILD_VERSION)
+
+// These defines are used in response to the GetInfo command.
+#define VERSION STR_VALUE(BUILD_VERSION) // This comes from get_version.py and is set by the build process.
+#define NAME STR_VALUE(MOBIFLIGHT_NAME)  // This comes from get_version.py and is set by the build process.
 
 // MobiFlight expects a board name, type, and serial number to come from the board
 // when requested. The serial number is stored in flash. The board type
@@ -165,7 +168,7 @@ void OnGetInfo()
 {
   cmdMessenger.sendCmdStart(MFMessage::kInfo);
   cmdMessenger.sendCmdArg(F("Collins FMS 3000"));
-  cmdMessenger.sendCmdArg(F("Collins FMS 3000"));
+  cmdMessenger.sendCmdArg(NAME);
   cmdMessenger.sendCmdArg(unique_serial_str);
   cmdMessenger.sendCmdArg(VERSION);
   cmdMessenger.sendCmdEnd();


### PR DESCRIPTION
Fixes #41

* Get the board name from an environment variable
* Set the environment variable in get_version.py via a parameter passed from the build scripts
* Update the output filename to include the panel location (pilot/co-pilot)
* Update build scripts to attach firmware correctly