### PR TITLE
"A" key causes board to lock up

### DIFF
--- a/include/KeyboardMatrix.h
+++ b/include/KeyboardMatrix.h
@@ -34,6 +34,7 @@ private:
   Adafruit_TCA8418 *_keyMatrix;
 
   void ProcessKeys();
+  void ReadKeyEvent();
   void ProcessClrDel(ButtonState);
   void ProcessDim(ButtonState);
 


### PR DESCRIPTION
Fixes #50

Strangest bug ever. Moving println statements around would make it come and go.

Got rid of it by re-writing the key detection logic to use the flow described in the chip's datasheet. No idea why this fixed it. 